### PR TITLE
Update documentation for v5 of styletron-react

### DIFF
--- a/components/code.js
+++ b/components/code.js
@@ -3,9 +3,9 @@ import { useHover } from "./hooks";
 import {
   styled,
   withStyle,
-  withStyleDeep,
   withTransform,
-  createStyled
+  createStyled,
+  useStyletron
 } from "styletron-react";
 import { driver, getInitialStyle } from "styletron-standard";
 import { DESKTOP_BREAKPOINT } from "../const";
@@ -38,12 +38,12 @@ const Code = ({ code }) => (
     scope={{
       styled,
       withStyle,
-      withStyleDeep,
       withTransform,
       useHover,
       createStyled,
       driver,
-      getInitialStyle
+      getInitialStyle,
+      useStyletron
     }}
   >
     <Editable>editable</Editable>

--- a/const.js
+++ b/const.js
@@ -21,11 +21,13 @@ export const ROUTES = [
       "Styled Components",
       "Props Filtering",
       "$as prop",
-      "$ref prop",
+      "$style prop",
+      "Refs",
       "Composing Styles",
       "displayName",
       "Themes",
-      "Testing"
+      "Testing",
+      "useStyletron Hook (NEW)"
     ]
   },
   {
@@ -50,11 +52,11 @@ export const ROUTES = [
       "Server",
       "styled",
       "withStyle",
-      "withStyleDeep",
       "withTransform",
       "withWrapper",
       "Provider",
-      "createStyled"
+      "createStyled",
+      "useStyletron"
     ]
   },
   { text: "GitHub", path: "https://github.com/styletron/styletron" }

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "react-live": "^1.12.0",
     "react-syntax-highlighter": "^10.1.2",
     "react-test-renderer": "^16.8.3",
-    "styletron-engine-atomic": "^1.0.13",
-    "styletron-react": "^4.4.4"
+    "styletron-engine-atomic": "^1.1.1",
+    "styletron-react": "^5.0.0"
   },
   "license": "MIT"
 }

--- a/pages/api.mdx
+++ b/pages/api.mdx
@@ -113,7 +113,6 @@ The [styletron-react](https://www.npmjs.com/package/styletron-react) package con
 
 - [`styled`](#styled)
 - [`withStyle`](#withstyle)
-- [`withStyleDeep`](#withstyledeep)
 - [`withTransform`](#withtransform)
 - [`withWrapper`](#withwrapper)
 - [`Provider`](#provider)
@@ -152,34 +151,7 @@ const Foo = styled("div", props => {
 import { withStyle } from "styletron-react";
 ```
 
-Use `withStyle` for style composition via shallow object merging.
-
-#### Params
-
-1. `styledComponent` (`StyledComponent`)
-2. `style` (`Style` | `(props: Object) => Style`)
-
-#### Examples
-
-```jsx
-const Foo = styled("div", { color: "red", background: "red" });
-
-// Static styles
-const Bar = withStyle(Foo, { background: "green" });
-
-// Prop-driven styles
-const Baz = withStyle(Foo, props => ({
-  letterSpacing: props.$crushed ? "-5px" : "0px"
-}));
-```
-
-### `withStyleDeep`
-
-```js
-import { withStyleDeep } from "styletron-react";
-```
-
-Use `withStyleDeep` for style composition via deep object merging.
+Use `withStyle` for style composition via deep object merging.
 
 #### Params
 
@@ -192,13 +164,16 @@ Use `withStyleDeep` for style composition via deep object merging.
 const Foo = styled("div");
 
 // Static styles
-const Bar = withStyleDeep(Foo, {":hover": {background: "green"}});
+const Bar = withStyle(Foo, {":hover": {background: "green"}});
 
 // Props-driven styles
-const Bar = withStyleDeep(Foo, props => ({
+const Bar = withStyle(Foo, props => ({
   ":hover": {background: props.$green ? "green" : "white"}
 });
 ```
+
+`withStyleDeep` has been deprecated in `v5` of Styletron.
+`withStyle` now performs a deep object merge by default as this was what was generally desired.
 
 ### `withTransform`
 
@@ -206,7 +181,7 @@ const Bar = withStyleDeep(Foo, props => ({
 import { withTransform } from "styletron-react";
 ```
 
-Shallow and deep object merging gets the job done most of the time, but for more control over composition, `withTransform` allows for direct style manipulation via an arbitrary transformation function.
+If you need more control over your styling composition, `withTransform` allows for direct style manipulation via an arbitrary transformation function.
 
 #### Params
 
@@ -288,7 +263,9 @@ const App = () => (
 
 #### Browser debug mode
 
-In the browser, there's an optional debug mode which will render debug classes to styled elements which point to the JS source location of the styled component. This mode can be enabled with the `debugMode` prop on the client side `Provider`.
+In the browser, there's an optional debug mode which will render debug classes to styled elements which point to the JS source location of the styled component.
+This mode can be enabled with the `debugMode` prop on the client side `Provider`.
+Note that in a Node context debugMode does not do anything.
 
 ##### Example
 
@@ -343,6 +320,14 @@ interface DebugEngine {
 }
 ```
 
+#### No-op engine fallback
+
+If you forget to wrap your application with Styletron's `Provider`, Styletron switches to a no-op mode (rather than crashing) and will log a warning to the console.
+You probably do not want this for your actual app, but it is a useful convenience when writing tests where you do not care about styling output.
+In those cases, you do not have to worry about setting up Styletron's `Provider`.
+
+Just be sure to set `NODE_ENV=test` to prevent a whole bunch of console warnings.
+
 ### `createStyled`
 
 ```js
@@ -378,4 +363,26 @@ const wrapper = StyledComponent => props => (
 );
 
 const styled = createStyled({ getInitialStyle, driver, wrapper });
+```
+
+### `useStyletron`
+
+A [React Hook](https://reactjs.org/docs/hooks-intro.html) that returns a function for generating Styletron CSS classes.
+
+#### `css` Params
+
+1. `style` (`(StyleObject) => string`)
+
+#### Examples
+
+```jsx
+import { useStyletron } from "styletron-react";
+
+const Button = () => {
+  // Use `css` to generate a string containing CSS classes
+  const [css] = useStyletron();
+
+  // Note how we pass the generated string directly to the `className` prop
+  return <button className={css({ color: "blue" })}>Blue Button</button>;
+};
 ```

--- a/pages/react.mdx
+++ b/pages/react.mdx
@@ -10,11 +10,13 @@ export default Layout;
 2. [Styled Components](#styled-components)
 3. [Props Filtering](#props-filtering)
 4. [`$as` prop](#as-prop)
-5. [`$ref` prop](#ref-prop)
-6. [Composing Styles](#composing-styles)
-7. [displayName](#displayname)
-8. [Themes](#themes)
-9. [Testing](#testing)
+5. [`$style` prop](#style-prop)
+6. [Refs](#refs)
+7. [Composing Styles](#composing-styles)
+8. [displayName](#displayname)
+9. [Themes](#themes)
+10. [Testing](#testing)
+11. [useStyletron Hook (NEW)](#usestyletron-hook-new)
 
 ## Motivation
 
@@ -187,51 +189,67 @@ The warning message above was manufactured since `$isActive` is filtered out by 
 
 This can be especially useful when you need to swap between `a` and `button` or `h1`, `h2`, `h3`. You don't need to create multiple styled components for that.
 
-## `$ref` prop
+## `$style` prop
 
-What are [React refs](https://reactjs.org/docs/refs-and-the-dom.html)?
+The `$style` property allows you to override styles directly on a styled component.
 
-> In the typical React dataflow, props are the only way that parent components interact with their children. To modify a child, you re-render it with new props. However, there are a few cases where you need to imperatively modify a child outside of the typical dataflow. The child to be modified could be an instance of a React component, or it could be a DOM element. For both of these cases, React provides an escape hatch.
-
-**Refs is an escape hatch so you can directly modify the instance of a React component**. For example, we have an input and button and we want to focus the input when the button is clicked:
+For example, we have some boring gray text.
+Let's make it beautiful by passing a `$style` override:
 
 ```jsx live
-class MyApp extends React.Component {
-  constructor() {
-    this.inputRef = React.createRef();
-  }
-  render() {
-    return (
-      <>
-        <input ref={this.inputRef} />
-        <button onClick={() => this.inputRef.current.focus()}>
-          Focus input
-        </button>
-      </>
-    );
-  }
-}
+() => {
+  const BoringText = styled("div", { color: "gray" });
+
+  return (
+    <>
+      <BoringText $style={{ color: "hotpink" }}>pretty in pink</BoringText>
+    </>
+  );
+};
 ```
 
-However, if `input` is not just a simple input but styled component `<Input />` this will not work:
+You can also pass `$style` a function for dynamic overriding based on props:
 
-```jsx
-import { styled } from "styletron-react";
+```jsx live
+() => {
+  const BoringText = styled("div", { color: "gray" });
 
-const Input = styled("input", { background: "#FFE1A5" });
-
-// …
-<Input ref={this.inputRef} />;
-// …
+  return (
+    <>
+      <BoringText
+        $style={props => ({ color: props.$special ? "hotpink" : "gray" })}
+        $special
+      >
+        pink panther
+      </BoringText>
+    </>
+  );
+};
 ```
 
-React will complain:
+`$style` also takes precendence over `withStyle`:
 
-> Warning: Function components cannot be given refs. Attempts to access this ref will fail. Did you mean to use React.forwardRef()?
+```jsx live
+() => {
+  const BoringText = styled("div", { color: "gray" });
+  const MostBoringText = withStyle(BoringText, { color: "dimgray" });
 
-**`styled` creates a function component** and not class based component. **Function components can't accept a ref**.
+  return (
+    <>
+      <MostBoringText $style={{ color: "hotpink" }}>
+        on wednesdays we wear pink
+      </MostBoringText>
+    </>
+  );
+};
+```
 
-React gives a great suggestion to library maintainers to forward refs with [React.forwardRef](https://reactjs.org/docs/forwarding-refs.html) API. This is a fairly new feature (React v16.3). Styletron [will most likely adopt it](https://github.com/styletron/styletron/issues/253) in the next major version. In meantime, Styletron provides an alternative ref forwarding scheme through the `$ref` prop:
+## Refs
+
+When you use a `ref` on a styled component it will be forwarded to the underlying element.
+
+For example, we have a styled input and a button.
+We want to focus the input when the button is clicked:
 
 ```jsx live
 import { styled } from "styletron-react";
@@ -244,7 +262,7 @@ class MyApp extends React.Component {
     const Input = styled("input", { background: "#FFE1A5" });
     return (
       <>
-        <Input $ref={this.inputRef} />
+        <Input ref={this.inputRef} />
         <button onClick={() => this.inputRef.current.focus()}>
           Focus input
         </button>
@@ -254,138 +272,118 @@ class MyApp extends React.Component {
 }
 ```
 
-**Just rename `ref` to `$ref`**. That's it!
+As expected, `this.inputRef` is forwarded to the underlying `input`.
+
+Previous versions of Styletron required refs to be passed using a `$ref` property.
+As of Styletron `v5` this work-around is no longer neccessary (thanks to `React.forwardRef`).
+
+[See here for more info on React Refs](https://reactjs.org/docs/refs-and-the-dom.html).
 
 ## Composing Styles
 
-Styled components are quite locked down. They come with defined styles and underlying DOM element. You can swap the DOM element with the [`$as` prop](#as-prop) but **what if you want to tweak some styles** as well?
+As you use Styletron you may eventually run into some fundamental questions:
 
-`styletron-react` exports several composition functions. These can be used to create new styled components by composing styles from existing ones. You don't need to create a new component from scratch. Perfect for tweaks!
+- How do I tweak a few styles on a styled component?
+- How do I reuse styles across multiple components?
 
-### withStyle
+Styletron offers a few strategies:
 
-Do you need to slightly modify an existing styled component like changing the color?
+1. Use the [`$style` prop](#style-prop) for direct component style overrides
+2. Compose existing styled component using the `withStyle` function
+3. Use props (`$type`, `$isActive`, etc) to allow customization of styled components
+
+Here are a few scenarios that map to these strategies:
+
+### Tweaks
+
+If you only need a slight modification to an existing styled component and reuse is not a concern, look no further than the [`$style` prop](#style-prop):
+
+```jsx live
+() => {
+  const Button = styled("button", {
+    color: "black",
+    border: "solid 1px currentColor"
+  });
+
+  return (
+    <>
+      <Button>Button</Button>
+      <Button $style={{ color: "red" }}>Button</Button>
+    </>
+  );
+};
+```
+
+### Reusing Styled Components
+
+If you want to reuse modifications to a styled component, consider the `withStyle` function, which returns a new styled component:
 
 ```jsx live
 import { withStyle, styled } from "styletron-react";
 
 export default () => {
-  const RedButton = styled("button", {
-    color: "red",
-    border: "2px solid black",
-    display: "block",
-    margin: "1em 0"
+  const Button = styled("button", {
+    color: "black",
+    border: "solid 1px currentColor"
   });
-  const BlueButton = withStyle(RedButton, { color: "blue" });
+  const BlueButton = withStyle(Button, { color: "blue" });
+
   return (
     <>
-      <RedButton>Red Button</RedButton>
+      <Button>Button</Button>
       <BlueButton>Blue Button</BlueButton>
     </>
   );
 };
 ```
 
-**`BlueButton` overrides the `color` property** but keeps other `RedButton`'s styles intact. This is especially useful if you don't own the `RedButton` component and you can't change its API (adding `$isBlue` prop?).
+**`BlueButton` overrides the `color` property** but keeps other `Button` styles intact.
+This is especially useful if you don't own the `Button` component and you can't change its API (by adding an `$isBlue` prop for example).
 
-### withStyleDeep
+### Expanding a styled component's API
 
-The style object can be nested when pseudo classes (`:hover`, `:focus`, etc.) are used. The problem is that `withStyle` blindly overrides only the first level:
+`withStyle` is a powerful tool but you should avoid over-using it.
+Oftentimes, it is better to update the original component and add some additional props to it.
 
-```jsx live
-import { withStyle, styled } from "styletron-react";
-
-export default () => {
-  const HoverRed = styled("button", {
-    ":hover": {
-      color: "red",
-      border: "2px dashed black"
-    },
-    border: "2px solid black",
-    display: "block",
-    margin: "1em 0"
-  });
-  const HoverBlue = withStyle(HoverRed, {
-    ":hover": {
-      color: "blue"
-    }
-  });
-  return (
-    <>
-      <HoverRed>Hover Red Button</HoverRed>
-      <HoverBlue>Hover Blue Button</HoverBlue>
-    </>
-  );
-};
-```
-
-`HoverBlue` gets blue when hovered but it doesn't have the dashed border anymore. That's because `withStyle` replaced the whole `:hover` property and _didn't look inside_. To fix that, you can use `withStyleDeep` instead:
-
-```jsx live
-import { withStyleDeep, styled } from "styletron-react";
-
-export default () => {
-  const HoverRed = styled("button", {
-    ":hover": {
-      color: "red",
-      border: "2px dashed black"
-    },
-    border: "2px solid black",
-    display: "block",
-    margin: "1em 0"
-  });
-  const HoverBlue = withStyleDeep(HoverRed, {
-    ":hover": {
-      color: "blue"
-    }
-  });
-  return (
-    <>
-      <HoverRed>Hover Red Button</HoverRed>
-      <HoverBlue>Hover Blue Button</HoverBlue>
-    </>
-  );
-};
-```
-
-`:hover` object is now deeply merged and `HoverBlue` preserves the dashed border style.
-
-#### Note
-
-`withStyle` and `withStyleDeep` are powerful functions but you should avoid over-using them. Often times, it's better to update the original component and add some additional props to it. For example, instead of
+For example, instead of:
 
 ```jsx
 const PrimaryButton = withStyle(Button, { color: "blue" });
-const SecondaryButton = withStyle(Button, { color: "green" });
-const TertiaryButton = withStyle(Button, { color: "yellow" });
+const SecondaryButton = withStyle(Button, { color: "turquoise" });
+const TertiaryButton = withStyle(Button, { color: "purple" });
 ```
 
-it might be better to add `type` property to the `Button` component
+it might be better to add a `$type` property to the `Button` component:
 
 ```jsx
-const getButtonColor = type => {
-  switch(type) {
+const getButtonColor = $type => {
+  switch ($type) {
     case "primary":
       return "blue";
     case "secondary":
-      return "green";
+      return "turquoise";
     case "tertiary":
-      return "yellow";
+      return "purple";
     default:
       return "black";
   }
-}
+};
+const Button = styled("button", props => ({
+  color: getButtonColor(props.$type),
+  border: "solid 1px currentColor"
+}));
 
-const Button = styled('button', props => ({
-  color: getButtonColor(props.type)
-}))
-
-<Button type="primary" />
-<Button type="secondary" />
-<Button type="tertiary" />
+return (
+  <>
+    <Button $type="primary">Primary</Button>
+    <Button $type="secondary">Secondary</Button>
+    <Button $type="tertiary">Tertiary</Button>
+  </>
+);
 ```
 
-It's more verbose but you will end up with a single component `Button` that doesn't rely on internal styles of some other component. In the future, you can decide to replace `color` by `backgroundColor` and it will not break "withStyled" components.
+It's more verbose but you will end up with a single component `Button` that doesn't rely on internal styles of some other component.
+In the future, you can decide to replace `color` by `backgroundColor` and it will not break `withStyled` components.
 
 ## displayName
 
@@ -515,7 +513,11 @@ Finally, we need to wrap the root of our application with `ThemeProvider` so the
 
 ## Testing
 
-You can test styled components as any other React component. Just don't forget to wrap the tested component with Styletron's `Provider`!
+You can test styled components as any other React component.
+If you want to test actual styling don't forget to wrap the tested component with Styletron's `Provider`!
+
+If you do not care about styling in your test you can omit the `Provider` and Styletron will use a no-op fallback engine.
+Just be sure to set `NODE_ENV=test` to prevent a whole bunch of console warnings.
 
 ### Snapshot Testing
 
@@ -567,3 +569,35 @@ We captured **both the HTML markup and related CSS**.
 The generated class names are not stable and will change often (unless the component is sandboxed as in the snapshot test above) so you should never target them. If you need a stable selector for your e2e tests, you should add `data-test-id` attribute.
 
 [Puppeteer](https://github.com/GoogleChrome/puppeteer) is a great solution for e2e test!
+
+## `useStyletron` Hook (NEW)
+
+🎉 New in `v5`, Styletron's first [React Hook](https://reactjs.org/docs/hooks-intro.html)!
+
+`useStyletron` introduces a lightweight approach to generating CSS classes for an element or component, **without having to opt in to the standard Styletron styled component API**.
+This allows you to style any element or component _directly_ while still taking advantage of Styletron's efficient CSS generation.
+
+```jsx live
+import { useStyletron } from "styletron-react";
+
+export default () => {
+  const [css] = useStyletron();
+  return (
+    <>
+      <button className={css({ color: "red" })}>Red Button</button>
+      <button className={css({ color: "blue" })}>Blue Button</button>
+    </>
+  );
+};
+```
+
+The `css` function returned by `useStyletron` returns a `string` containing the CSS classes required to style the component.
+We can pass this string directly to an element or component's `classNames` property.
+
+Even more awesome- if you are using `styletron-engine-atomic` the classes returned by `css` will still be deduped with the rest of your Styletron atomic CSS.
+You get all the benefits of inline styling without any of the negative effects-- with almost none of the overhead associated with a styled component.
+
+### Caveats
+
+- By opting out of a styled component you do give up some useful features such as built in overriding, composability, and reusability.
+- You still need to wrap your application code in a Styletron `<Provider />` for the `useStyletron` hook to work correctly.

--- a/yarn.lock
+++ b/yarn.lock
@@ -6564,27 +6564,26 @@ styled-jsx@3.2.1:
     stylis "3.5.4"
     stylis-rule-sheet "0.0.10"
 
-styletron-engine-atomic@^1.0.13:
-  version "1.0.13"
-  resolved "https://registry.yarnpkg.com/styletron-engine-atomic/-/styletron-engine-atomic-1.0.13.tgz#0c53ec9c39fe153a7359f747ee677d54737cec10"
-  integrity sha512-aN1FKxEZwGwVoHtm9us/LxCKhe/hSQScu+4fZhc9jWa9S3ZX91L1vybrAHqsRYdLgtfmtCwJwfzuX1Nwm0/bxw==
+styletron-engine-atomic@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/styletron-engine-atomic/-/styletron-engine-atomic-1.1.1.tgz#5893b9589c0b4c631fffa610102d5df4c0e52902"
+  integrity sha512-Dcu2vIhMqoef4f0ErQdYjcE8UTzsYY7AJDT8Zf+1HFdFEwDl5QmL7pZ9SH93093IOXF76R48NduuXCz90frv/w==
   dependencies:
     inline-style-prefixer "^4.0.0"
-    styletron-standard "^2.0.1"
+    styletron-standard "^2.0.2"
 
-styletron-react@^4.4.4:
-  version "4.4.4"
-  resolved "https://registry.yarnpkg.com/styletron-react/-/styletron-react-4.4.4.tgz#5d68d8ed81286ee502a61191a5d6a2169ffdcb72"
-  integrity sha512-MdXCITPtqjKu+5bbWXjCEZ8VTvYEezEx8a1GgvWbdUhLwR1J+N0Sw6PExUi/O2iJJgQBM4reaoIadbczWJu45Q==
+styletron-react@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/styletron-react/-/styletron-react-5.0.0.tgz#51d1b8517aa68bd143579a95979325ee64e2dbac"
+  integrity sha512-Otk9HUkybsUO9MTjXfux2nB+Cs5RuMWxL/cylnxyFU+rMHFEhLDRjjKYo92Wx331Uq4TS9AQ5hcRLYQIl6uzug==
   dependencies:
-    create-react-context "^0.2.2"
     prop-types "^15.6.0"
-    styletron-standard "^2.0.1"
+    styletron-standard "^2.0.2"
 
-styletron-standard@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/styletron-standard/-/styletron-standard-2.0.1.tgz#09ea1e339876f56d80e3e0bf1cbc62490c9ac03f"
-  integrity sha512-yLUdUk9HDpXtuORy1VQqdc77idC2ayuTt2/F5FXy66u4VyDSAi4L0MDveZoUnkJf66wMErO8Pb70eHa1J5R8JQ==
+styletron-standard@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/styletron-standard/-/styletron-standard-2.0.2.tgz#24bbbdfb353dc0f4ce6ffe6077bae7ec204c27cd"
+  integrity sha512-GceZ3uBtRYKl6FS5ZxsAG8zP0BzDfj5DISnjLMleQrZsjE00eyuwn7Lr2KlQ4u7AtPdr3SO037cyc/8TCDotmg==
   dependencies:
     inline-style-prefixer "^4.0.0"
 


### PR DESCRIPTION
- Bump `styletron-react` dep to `v5.0.0`
- Bump `styletron-engine-atomic` dep to `v1.1.1`
- Update documentation covering...
  - Default no-op engine
  - `$ref` to `ref`
  - New `$style` prop
  - Remove `withStyleDeep`
  - New `useStyletron` hook
  - Other tangential tweaks to copy
