### PR TITLE
Move and rename the useStyletron docs

### DIFF
--- a/components/layout.js
+++ b/components/layout.js
@@ -109,6 +109,7 @@ class Layout extends React.Component {
     const anchors = ROUTES[pathIndex].anchors;
     let activeAnchor = anchors[0];
     anchors.forEach(anchor => {
+      console.log(cleanAnchor(anchor));
       const el = document.getElementById(cleanAnchor(anchor));
       if (el.getBoundingClientRect().top - 26 < 0) {
         activeAnchor = anchor;

--- a/components/layout.js
+++ b/components/layout.js
@@ -109,7 +109,6 @@ class Layout extends React.Component {
     const anchors = ROUTES[pathIndex].anchors;
     let activeAnchor = anchors[0];
     anchors.forEach(anchor => {
-      console.log(cleanAnchor(anchor));
       const el = document.getElementById(cleanAnchor(anchor));
       if (el.getBoundingClientRect().top - 26 < 0) {
         activeAnchor = anchor;

--- a/const.js
+++ b/const.js
@@ -22,12 +22,12 @@ export const ROUTES = [
       "Props Filtering",
       "$as prop",
       "$style prop",
+      "useStyletron Hook",
       "Refs",
       "Composing Styles",
       "displayName",
       "Themes",
-      "Testing",
-      "useStyletron Hook (NEW)"
+      "Testing"
     ]
   },
   {

--- a/pages/react.mdx
+++ b/pages/react.mdx
@@ -11,12 +11,12 @@ export default Layout;
 3. [Props Filtering](#props-filtering)
 4. [`$as` prop](#as-prop)
 5. [`$style` prop](#style-prop)
-6. [Refs](#refs)
-7. [Composing Styles](#composing-styles)
-8. [displayName](#displayname)
-9. [Themes](#themes)
-10. [Testing](#testing)
-11. [useStyletron Hook (NEW)](#usestyletron-hook-new)
+6. [useStyletron Hook](#usestyletron-hook)
+7. [Refs](#refs)
+8. [Composing Styles](#composing-styles)
+9. [displayName](#displayname)
+10. [Themes](#themes)
+11. [Testing](#testing)
 
 ## Motivation
 
@@ -243,6 +243,38 @@ You can also pass `$style` a function for dynamic overriding based on props:
   );
 };
 ```
+
+## `useStyletron` Hook
+
+🎉 New in `v5`, Styletron's first [React Hook](https://reactjs.org/docs/hooks-intro.html)!
+
+`useStyletron` introduces a lightweight approach to generating CSS classes for an element or component, **without having to opt in to the standard Styletron styled component API**.
+This allows you to style any element or component _directly_ while still taking advantage of Styletron's efficient CSS generation.
+
+```jsx live
+import { useStyletron } from "styletron-react";
+
+export default () => {
+  const [css] = useStyletron();
+  return (
+    <>
+      <button className={css({ color: "red" })}>Red Button</button>
+      <button className={css({ color: "blue" })}>Blue Button</button>
+    </>
+  );
+};
+```
+
+The `css` function returned by `useStyletron` returns a `string` containing the CSS classes required to style the component.
+We can pass this string directly to an element or component's `classNames` property.
+
+Even more awesome- if you are using `styletron-engine-atomic` the classes returned by `css` will still be deduped with the rest of your Styletron atomic CSS.
+You get all the benefits of inline styling without any of the negative effects-- with almost none of the overhead associated with a styled component.
+
+### Caveats
+
+- By opting out of a styled component you do give up some useful features such as built in overriding, composability, and reusability.
+- You still need to wrap your application code in a Styletron `<Provider />` for the `useStyletron` hook to work correctly.
 
 ## Refs
 
@@ -569,35 +601,3 @@ We captured **both the HTML markup and related CSS**.
 The generated class names are not stable and will change often (unless the component is sandboxed as in the snapshot test above) so you should never target them. If you need a stable selector for your e2e tests, you should add `data-test-id` attribute.
 
 [Puppeteer](https://github.com/GoogleChrome/puppeteer) is a great solution for e2e test!
-
-## `useStyletron` Hook (NEW)
-
-🎉 New in `v5`, Styletron's first [React Hook](https://reactjs.org/docs/hooks-intro.html)!
-
-`useStyletron` introduces a lightweight approach to generating CSS classes for an element or component, **without having to opt in to the standard Styletron styled component API**.
-This allows you to style any element or component _directly_ while still taking advantage of Styletron's efficient CSS generation.
-
-```jsx live
-import { useStyletron } from "styletron-react";
-
-export default () => {
-  const [css] = useStyletron();
-  return (
-    <>
-      <button className={css({ color: "red" })}>Red Button</button>
-      <button className={css({ color: "blue" })}>Blue Button</button>
-    </>
-  );
-};
-```
-
-The `css` function returned by `useStyletron` returns a `string` containing the CSS classes required to style the component.
-We can pass this string directly to an element or component's `classNames` property.
-
-Even more awesome- if you are using `styletron-engine-atomic` the classes returned by `css` will still be deduped with the rest of your Styletron atomic CSS.
-You get all the benefits of inline styling without any of the negative effects-- with almost none of the overhead associated with a styled component.
-
-### Caveats
-
-- By opting out of a styled component you do give up some useful features such as built in overriding, composability, and reusability.
-- You still need to wrap your application code in a Styletron `<Provider />` for the `useStyletron` hook to work correctly.


### PR DESCRIPTION
Removed `(New)` from the header so the anchor link doesn't break in the future (it doesn't make sense to keep the `new` label there forever). Also, moved it to the middle of page so it follows the documentation related to `styled`.