### PR TITLE
Fix link for props filtering explanation

### DIFF
--- a/pages/concepts.mdx
+++ b/pages/concepts.mdx
@@ -84,7 +84,7 @@ export default () => {
 };
 ```
 
-If you wonder why we called our prop `$compact` and not just `compact`, see [the explanation](/react#as-prop).
+If you wonder why we called our prop `$compact` and not just `compact`, see [the explanation](/react#props-filtering).
 
 ## Media Queries And Pseudo Classes
 


### PR DESCRIPTION
When reading the docs I saw that the link for explaining why `$` is used for props was pointing to the section right after where it's actually explained.