### PR TITLE
add monolithic api reference

### DIFF
--- a/components/navigation.js
+++ b/components/navigation.js
@@ -9,7 +9,7 @@ const SidebarItem = styled("li", ({ $anchor, $active }) => ({
     ? "0rem 2rem 0.75rem 3rem"
     : `0.75rem 2rem ${$active ? "0.5rem" : "0.75rem"} 2rem`,
   fontSize: $anchor ? "14px" : "16px",
-  width: "8em"
+  width: "14em"
 }));
 
 const StyledLink = styled("a", ({ $active }) => ({
@@ -27,7 +27,7 @@ const SidebarList = styled("ul", ({ $isVisible }) => ({
   padding: "0.5em 0em",
   borderLeft: "none",
   position: "absolute",
-  width: "15em",
+  width: "16em",
   right: "-6px",
   borderRadius: "6px",
   boxShadow: "rgba(0, 0, 0, 0.3) 0 2px 10px",

--- a/const.js
+++ b/const.js
@@ -49,8 +49,8 @@ export const ROUTES = [
     text: "API",
     path: "/api-reference",
     anchors: [
-      "Client",
-      "Server",
+      "styletron-engine-monolithic",
+      "styletron-engine-atomic",
       "styled",
       "withStyle",
       "withTransform",

--- a/pages/api-reference.mdx
+++ b/pages/api-reference.mdx
@@ -4,8 +4,109 @@ export default Layout;
 
 # API
 
-1. [styletron-engine-atomic](#styletron-engine-atomic)
-2. [styletron-react](#styletron-react)
+1. [styletron-engine-monolithic](#styletron-engine-monolithic)
+2. [styletron-engine-atomic](#styletron-engine-atomic)
+3. [styletron-react](#styletron-react)
+
+## styletron-engine-monolithic
+
+Monolithic implementation of the [styletron-standard](https://www.npmjs.com/package/styletron-standard) engine interface. This package [styletron-engine-monolithic](https://www.npmjs.com/package/styletron-engine-monolithic) provides two named exports:
+
+- [`Client`](#client) - Client-side engine class
+- [`Server`](#server) - Server-side engine class
+
+### `Client`
+
+```js
+import { Client } from "styletron-engine-monolithic";
+```
+
+#### `.constructor(opts?: {prefix?: string, hydrate?: HTMLStyleElement[], container: Element})`
+
+##### Options
+
+- `prefix?: string` The prefix to be used for all generated class names.
+- `hydrate?: HTMLStyleElement[]` Collection of server-rendered style elements. Hydration is required when server-side rendering.
+- `container?: Element` The element that new stylesheets should be appended to. Defaults to the parent element of the first stylesheet passed via `hydrate`, otherwise defaults to `document.head`.
+
+```js
+const instance = new Client();
+```
+
+- [`.renderStyle(style) => string`](#renderstylestyle-string)
+- [`.renderKeyframes(keyframes) => string`](#renderkeyframeskeyframes-string)
+- [`.renderFontFace(fontFace) => string`](#renderfontfacefontface-string)
+
+### `Server`
+
+```js
+import { Server } from "styletron-engine-monolithic";
+```
+
+#### `.constructor(opts?: {prefix?: string})`
+
+##### Options
+
+- `prefix?: string` The prefix to be used for all generated class names.
+
+```js
+const instance = new Server();
+```
+
+#### `.getStylesheets() => Array<{css: string, attrs: {[string]: string}}>`
+
+Returns styles as an array of stylesheet objects.
+
+#### `.getStylesheetsHtml(className: string) => string`
+
+Returns styles as a string of HTML that can also be used for client-side hydration.
+
+#### `.getCss() => string`
+
+Returns styles as a string of CSS for purely server-side rendering use cases where no client-side hydration is needed.
+
+- [`.renderStyle(style) => string`](#renderstylestyle-string)
+- [`.renderKeyframes(keyframes) => string`](#renderkeyframeskeyframes-string)
+- [`.renderFontFace(fontFace) => string`](#renderfontfacefontface-string)
+
+### Universal methods
+
+These methods exist on both the server and client instances.
+
+#### `.renderStyle(style) => string`
+
+Renders a given style object, returning the corresponding generated class name.
+
+```js
+instance.renderStyle({
+  color: "red",
+  fontSize: "12px",
+});
+// → "css-abc"
+```
+
+#### `.renderKeyframes(keyframes) => string`
+
+Renders a given keyframes object, returning the corresponding generated `@keyframes` rule name.
+
+```js
+const animationName = instance.renderKeyframes({
+  from: { color: "red" },
+  to: { color: "blue" },
+});
+// → "animation-abc"
+```
+
+#### `.renderFontFace(fontFace) => string`
+
+Renders a given font face object, returning the font-family name from the corresponding generated `@font-face` rule.
+
+```js
+const fontFamily = instance.renderFontFace({
+  src: "...",
+});
+// → "font-abc"
+```
 
 ## styletron-engine-atomic
 


### PR DESCRIPTION
Spent a while considering better ways to split api-reference into separate pages, but chose not to rewrite the navigation UI